### PR TITLE
Improved script extensibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # redyt
+
 Scrape Reddit images from the Terminal
 
 This shell script will automatically create the following folder:
@@ -23,3 +24,16 @@ Please note: you will need to install the following programs:
   - sxiv (Image Viewing)
 
 `notify-send` is also recommended but, if not present, `echo` will be used as a notifier.
+
+## Usage
+
+```sh
+$ redyt [-l LIMIT] [-v] [-k] [SUBREDDIT]
+$ redyt [--limit LIMIT] [--verbose] [--keep] [SUBREDDIT]
+```
+
+## Arguments
+
+* `-l LIMIT, --limit LIMIT` set the maximum number of files to be downloaded
+* `-k, --keep` don't remove files after quitting `sxiv`
+* `-v, --verbose` use notifier

--- a/redyt
+++ b/redyt
@@ -80,6 +80,7 @@ wget -P "$cachedir" $imgs
 
 # Send a notification
 [ $VERBOSE ] && $notifier  "Redyt" "👍 Download Finished, Enjoy! 😊"
+rm "$cachedir/tmp.json"
 
 # Display the images
 sxiv -a "$cachedir"

--- a/redyt
+++ b/redyt
@@ -73,7 +73,7 @@ if [ ! -d "$cachedir" ]; then
 fi
 
 # Send a notification
-[ $VERBOSE ] && $notifier "Redyt" "📩 Downloading your 🖼️ Memes"
+[ $VERBOSE -eq 1 ] && $notifier "Redyt" "📩 Downloading your 🖼️ Memes"
 
 # Download the subreddit feed, containing only the
 # first 100 entries (limit), and store it inside
@@ -94,15 +94,15 @@ for img in $imgs; do
 done
 
 # Send a notification
-[ $VERBOSE ] && $notifier  "Redyt" "👍 Download Finished, Enjoy! 😊"
+[ $VERBOSE -eq 1 ] && $notifier  "Redyt" "👍 Download Finished, Enjoy! 😊"
 rm "$cachedir/tmp.json"
 
 # Display the images
-if [ $FILTER ]; then
+if [ $FILTER -eq 1 ]; then
 	sxiv -a -o "$cachedir"
 else
 	sxiv -a "$cachedir"
 fi
 
 # Once finished, remove all of the cached images
-[ ! $KEEP ] && rm "${cachedir:?}"/*
+[ ! $KEEP -eq 1 ] && rm "${cachedir:?}"/*

--- a/redyt
+++ b/redyt
@@ -25,7 +25,7 @@ defaultsub="linuxmemes"
 # If no argument is passed
 if [ -z "$1" ]; then
 	# Ask the user to enter a subreddit
-	subreddit=$(dmenu -p "Select Subreddit r/" -i -l 10 < "$configdir/subreddit.txt" | cut -d\| -f1 | awk '{$1=$1;print}')
+	subreddit=$(dmenu -p "Select Subreddit r/" -i -l 10 < "$configdir/subreddit.txt" | awk -F "|" '{print $1}')
 
 	# If no subreddit was chosen, exit
 	[ -z "$subreddit" ] && exit 1

--- a/redyt
+++ b/redyt
@@ -10,6 +10,16 @@ done
 # args
 while [ $# -gt 0 ]; do
 	case $1 in
+		-l|--limit)
+			shift
+			LIMIT=$1
+			case $LIMIT in
+				''|*[!0-9]*)
+					echo 'limit is NaN'
+					exit 1
+			esac
+			shift
+			;;
 		-k|--keep)
 			KEEP=1
 			shift
@@ -59,7 +69,7 @@ if [ ! -d "$cachedir" ]; then
 fi
 
 # Limit the maximum number of requests to make
-limit=100
+limit=${LIMIT:-100}
 
 # Send a notification
 [ $VERBOSE ] && $notifier "Redyt" "📩 Downloading your 🖼️ Memes"

--- a/redyt
+++ b/redyt
@@ -7,6 +7,16 @@ done
 # If notify-send is not installed, use echo as notifier
 [ ! "$(which notify-send)" ] && notifier="echo" || notifier="notify-send"
 
+# args
+while [ $# -gt 0 ]; do
+	case $1 in
+		*)
+			subreddit=$1
+			shift
+			;;
+	esac
+done
+
 # Default config directory
 configdir="${XDG_CONFIG_HOME:-$HOME/.config}/redyt"
 
@@ -28,12 +38,7 @@ if [ -z "$1" ]; then
 	subreddit=$(dmenu -p "Select Subreddit r/" -i -l 10 < "$configdir/subreddit.txt" | awk -F "|" '{print $1}')
 
 	# If no subreddit was chosen, exit
-	[ -z "$subreddit" ] && exit 1
-
-# Otherwise assign the first argument to the
-# subreddit variable
-else
-	subreddit="$1"
+	[ -z "$subreddit" ] && echo "no sub chosen" && exit 1
 fi
 
 # Default directory used to store the feed file and fetched images

--- a/redyt
+++ b/redyt
@@ -68,16 +68,13 @@ if [ ! -d "$cachedir" ]; then
 	mkdir -p "$cachedir"
 fi
 
-# Limit the maximum number of requests to make
-limit=${LIMIT:-100}
-
 # Send a notification
 [ $VERBOSE ] && $notifier "Redyt" "📩 Downloading your 🖼️ Memes"
 
 # Download the subreddit feed, containing only the
 # first 100 entries (limit), and store it inside
 # cachedir/tmp.json
-curl -H "User-agent: 'your bot 0.1'" "https://www.reddit.com/r/$subreddit/hot.json?limit=$limit" > "$cachedir/tmp.json"
+curl -H "User-agent: 'your bot 0.1'" "https://www.reddit.com/r/$subreddit/hot.json?limit=${LIMIT:-100}" > "$cachedir/tmp.json"
 
 # Create a list of images
 imgs=$(jq '.' < "$cachedir/tmp.json" | grep url_overridden_by_dest | grep -Eo "http(s|)://.*(jpg|png)\b" | sort -u)

--- a/redyt
+++ b/redyt
@@ -86,7 +86,11 @@ imgs=$(jq '.' < "$cachedir/tmp.json" | grep url_overridden_by_dest | grep -Eo "h
 [ -z "$imgs" ] && $notifier "Redyt" "sadly, there are no images for subreddit $subreddit, please try again later!" && exit 1
 
 # Download images to $cachedir
-wget -P "$cachedir" $imgs
+for img in $imgs; do
+	if [ ! -e "$cachedir/${img##*/}" ]; then
+		wget -P "$cachedir" $img
+	fi
+done
 
 # Send a notification
 [ $VERBOSE ] && $notifier  "Redyt" "👍 Download Finished, Enjoy! 😊"

--- a/redyt
+++ b/redyt
@@ -10,6 +10,10 @@ done
 # args
 while [ $# -gt 0 ]; do
 	case $1 in
+		-v|--verbose)
+			VERBOSE=1
+			shift
+			;;
 		*)
 			subreddit=$1
 			shift
@@ -54,7 +58,7 @@ fi
 limit=100
 
 # Send a notification
-$notifier "Redyt" "📩 Downloading your 🖼️ Memes"
+[ $VERBOSE ] && $notifier "Redyt" "📩 Downloading your 🖼️ Memes"
 
 # Download the subreddit feed, containing only the
 # first 100 entries (limit), and store it inside
@@ -71,7 +75,7 @@ imgs=$(jq '.' < "$cachedir/tmp.json" | grep url_overridden_by_dest | grep -Eo "h
 wget -P "$cachedir" $imgs
 
 # Send a notification
-$notifier  "Redyt" "👍 Download Finished, Enjoy! 😊"
+[ $VERBOSE ] && $notifier  "Redyt" "👍 Download Finished, Enjoy! 😊"
 
 # Display the images
 sxiv -a "$cachedir"

--- a/redyt
+++ b/redyt
@@ -69,7 +69,7 @@ wget -P "$cachedir" $imgs
 $notifier  "Redyt" "👍 Download Finished, Enjoy! 😊"
 
 # Display the images
-sxiv -a "$cachedir"/*.png "$cachedir"/*.jpg
+sxiv -a "$cachedir"
 
 # Once finished, remove all of the cached images
 rm "${cachedir:?}"/*

--- a/redyt
+++ b/redyt
@@ -20,6 +20,10 @@ while [ $# -gt 0 ]; do
 			esac
 			shift
 			;;
+		-f|--filter)
+			FILTER=1
+			shift
+			;;
 		-k|--keep)
 			KEEP=1
 			shift
@@ -94,7 +98,11 @@ done
 rm "$cachedir/tmp.json"
 
 # Display the images
-sxiv -a "$cachedir"
+if [ $FILTER ]; then
+	sxiv -a -o "$cachedir"
+else
+	sxiv -a "$cachedir"
+fi
 
 # Once finished, remove all of the cached images
 [ ! $KEEP ] && rm "${cachedir:?}"/*

--- a/redyt
+++ b/redyt
@@ -51,7 +51,7 @@ defaultsub="linuxmemes"
 [ ! -f "$configdir/subreddit.txt" ] && echo "$defaultsub" >> "$configdir/subreddit.txt"
 
 # If no argument is passed
-if [ -z "$1" ]; then
+if [ -z "$subreddit" ]; then
 	# Ask the user to enter a subreddit
 	subreddit=$(dmenu -p "Select Subreddit r/" -i -l 10 < "$configdir/subreddit.txt" | awk -F "|" '{print $1}')
 

--- a/redyt
+++ b/redyt
@@ -18,7 +18,7 @@ configdir="${XDG_CONFIG_HOME:-$HOME/.config}/redyt"
 # if it does not exist
 defaultsub="linuxmemes"
 
-# If subbreddit.txt does not exist, create it to prevent
+# If subreddit.txt does not exist, create it to prevent
 # the program from not functioning properly
 [ ! -f "$configdir/subreddit.txt" ] && echo "$defaultsub" >> "$configdir/subreddit.txt"
 

--- a/redyt
+++ b/redyt
@@ -10,6 +10,10 @@ done
 # args
 while [ $# -gt 0 ]; do
 	case $1 in
+		-k|--keep)
+			KEEP=1
+			shift
+			;;
 		-v|--verbose)
 			VERBOSE=1
 			shift
@@ -81,4 +85,4 @@ wget -P "$cachedir" $imgs
 sxiv -a "$cachedir"
 
 # Once finished, remove all of the cached images
-rm "${cachedir:?}"/*
+[ ! $KEEP ] && rm "${cachedir:?}"/*


### PR DESCRIPTION
Implemented a argument parser with, by now, three options:
* `-l LIMIT, --limit LIMIT` set the maximum number of files to be downloaded
* `-k, --keep` don't remove files after quitting `sxiv`
* `-v, --verbose` use notifier

To check the options, I've used a simpler notation: `[ $OPT ] && cmd`. I'm not quite sure if that is problem for a particular case.

Since now it is possible to keep the media, I've used a `for` loop over the urls to check if the file already exists. Made use of the shell's string manipulation.

More options could be easily added into the parser. 

I've made small changes in the `awk` command.