### PR TITLE
Proper way of checking existence of a program

### DIFF
--- a/redyt
+++ b/redyt
@@ -1,11 +1,18 @@
 #!/bin/sh
 
+is_installed() {
+    # Utility function for testing the existance of given program in the
+    # system.
+
+    [ -x "$(command -v "$1")" ]
+}
+
 # Check if necessary programs are installed
 for prog in dmenu jq sxiv; do
-	[ ! "$(which "$prog")" ] && echo "Please install $prog!" && exit 1
+    ! is_installed "$prog" && echo "Please install $prog!" && exit 1
 done
 # If notify-send is not installed, use echo as notifier
-[ ! "$(which notify-send)" ] && notifier="echo" || notifier="notify-send"
+! is_installed 'notify-send' && notifier="echo" || notifier="notify-send"
 
 # Default config directory
 configdir="${XDG_CONFIG_HOME:-$HOME/.config}/redyt"


### PR DESCRIPTION
This explains why this method works best:
https://stackoverflow.com/questions/592620/how-can-i-check-if-a-program-exists-from-a-bash-script

I added the extra `-x` flag as this also checks if the given command is
a binary, this makes the check ignore user-defined aliases and
functions.