### PR TITLE
Set a less conspicuous user agent

### DIFF
--- a/redyt
+++ b/redyt
@@ -52,7 +52,7 @@ limit=100
 $notifier "Redyt" "📩 Downloading your 🖼️ Memes"
 
 # Set user agent
-$useragent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36"
+useragent=$(shuf -e "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4482.0 Safari/537.36 Edg/92.0.874.0" "Mozilla/5.0 (Macintosh; Intel Mac OS X 11_3) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1 Safari/605.1.15" -n 1)
 
 # Download the subreddit feed, containing only the
 # first 100 entries (limit), and store it inside

--- a/redyt
+++ b/redyt
@@ -51,10 +51,14 @@ limit=100
 # Send a notification
 $notifier "Redyt" "📩 Downloading your 🖼️ Memes"
 
+# Set user agent
+$useragent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36"
+
 # Download the subreddit feed, containing only the
 # first 100 entries (limit), and store it inside
 # cachedir/tmp.json
-curl -H "User-agent: 'your bot 0.1'" "https://www.reddit.com/r/$subreddit/hot.json?limit=$limit" > "$cachedir/tmp.json"
+curl -H "User-agent: '$useragent'" "https://www.reddit.com/r/$subreddit/hot.json?limit=$limit" > "$cachedir/tmp.json"
+
 
 # Create a list of images
 imgs=$(jq '.' < "$cachedir/tmp.json" | grep url_overridden_by_dest | grep -Eo "http(s|)://.*(jpg|png)\b" | sort -u)


### PR DESCRIPTION
It would be better to look more like normal traffic by setting a common user agent.

We could even make it randomly select one from a list on each run.